### PR TITLE
fix(batch): count CostTracker requests even without litellm

### DIFF
--- a/promptpressure/batch.py
+++ b/promptpressure/batch.py
@@ -90,12 +90,17 @@ class CostTracker:
         self.costs = {}
 
     def record(self, model, response):
-        """Record cost from a litellm response object or raw usage dict."""
-        if not LITELLM_AVAILABLE:
-            return
+        """Record a request and its cost from a litellm response or raw usage dict.
 
+        Request counts are tracked even when litellm is unavailable; only the
+        cost figure depends on litellm's pricing data (it stays 0 without it).
+        """
         if model not in self.costs:
             self.costs[model] = {"input_cost": 0.0, "output_cost": 0.0, "total": 0.0, "requests": 0}
+        self.costs[model]["requests"] += 1
+
+        if not LITELLM_AVAILABLE:
+            return
 
         try:
             usage = None
@@ -114,17 +119,21 @@ class CostTracker:
                     completion=str(completion_tokens),
                 )
                 self.costs[model]["total"] += cost
-                self.costs[model]["requests"] += 1
         except Exception:
-            self.costs[model]["requests"] += 1
+            pass
 
     def record_from_usage(self, model, prompt_tokens, completion_tokens):
-        """Record cost from raw token counts."""
-        if not LITELLM_AVAILABLE:
-            return
+        """Record a request and its cost from raw token counts.
 
+        Request counts are tracked even when litellm is unavailable; only the
+        cost figure depends on litellm's pricing data (it stays 0 without it).
+        """
         if model not in self.costs:
             self.costs[model] = {"input_cost": 0.0, "output_cost": 0.0, "total": 0.0, "requests": 0}
+        self.costs[model]["requests"] += 1
+
+        if not LITELLM_AVAILABLE:
+            return
 
         try:
             cost = litellm.completion_cost(
@@ -133,9 +142,8 @@ class CostTracker:
                 completion=str(completion_tokens),
             )
             self.costs[model]["total"] += cost
-            self.costs[model]["requests"] += 1
         except Exception:
-            self.costs[model]["requests"] += 1
+            pass
 
     def summary(self):
         """Return cost summary dict."""


### PR DESCRIPTION
## why

CI is red on main. `tests/test_batch.py::TestCostTracker` has 3 failing tests (`KeyError: 'test-model'`), and they fail on a clean checkout too - this is pre-existing, not caused by any recent change.

root cause: `CostTracker.record()` and `record_from_usage()` both early-`return` when `LITELLM_AVAILABLE` is false. litellm is an optional dependency and isn't installed in the CI test environment, so every call was a no-op, `self.costs` stayed empty, and `summary()["per_model"]` came back with no keys. callers that index by model name then `KeyError`.

## fix

always create the per-model entry and increment the request count; gate only the *cost* computation on litellm (cost stays `0.0` when it's absent). request counting is the part that should never depend on an optional pricing library.

## verification

- the 4 `TestCostTracker` tests pass
- full suite green locally: 173 passed (excluding `test_api_launcher.py`, which needs `cachetools` not installed in my local env; it passes in CI)
- no behavior change when litellm IS installed - cost is still computed and added